### PR TITLE
added separation timing fields to sfdc query

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -5,6 +5,7 @@ module.exports = {
   SFDC_SELECT_QUERY: `Id, Student__c, Student__r.Name,
   Student__r.Email, Student__r.Secondary_Email__c, Campus_Formatted__c,
   Student__r.Github_Username__c, Course_Start_Date_Actual__c, Product_Code__c,
-  StageName, Separation_Status__c, Separation_Type__c, Separation_Reason__c, Last_Day_Of_Attendance__c,
-  Last_Day_of_Attendance_Acronym__c, Official_Withdrawal_Date__c`,
+  StageName, Separation_Status__c, Separation_Type__c, Separation_Reason__c,
+  Last_Day_Of_Attendance__c, Last_Day_of_Attendance_Acronym__c,
+  Official_Withdrawal_Date__c`,
 };

--- a/constants.js
+++ b/constants.js
@@ -5,5 +5,6 @@ module.exports = {
   SFDC_SELECT_QUERY: `Id, Student__c, Student__r.Name,
   Student__r.Email, Student__r.Secondary_Email__c, Campus_Formatted__c,
   Student__r.Github_Username__c, Course_Start_Date_Actual__c, Product_Code__c,
-  StageName, Separation_Status__c, Separation_Type__c`,
+  StageName, Separation_Status__c, Separation_Type__c, Separation_Reason__c, Last_Day_Of_Attendance__c,
+  Last_Day_of_Attendance_Acronym__c, Official_Withdrawal_Date__c`,
 };

--- a/salesforce/index.js
+++ b/salesforce/index.js
@@ -37,6 +37,10 @@ const formatStudents = (students) => {
       stage: student.StageName,
       separationStatus: student.Separation_Status__c,
       separationType: student.Separation_Type__c,
+      separationReason: student.Separation_Reason__c,
+      lastDayOfAttendance: student.Last_Day_Of_Attendance__c,
+      lastDayOfAttendanceAcronym: student.Last_Day_of_Attendance_Acronym__c,
+      dateOfDetermination: student.Official_Withdrawal_Date__c,
       sfdcContactId: student.Student__c,
       sfdcOpportunityId: student.Id,
     };

--- a/salesforce/salesforce.test.js
+++ b/salesforce/salesforce.test.js
@@ -46,6 +46,10 @@ describe('getStudents', () => {
       'stage',
       'separationStatus',
       'separationType',
+      'separationReason',
+      'lastDayOfAttendance',
+      'lastDayOfAttendanceAcronym',
+      'dateOfDetermination',
       'sfdcContactId',
       'sfdcOpportunityId',
     ];


### PR DESCRIPTION
now getting these student data fields with sfdc query:
Separation Reason (technical competency, attendance, etc)
Last Day of Attendance (2020-05-12)
Last Day of Attendance Acronym (W1D2) <-- only for post w1d1 seps
Date of Determination (date staff filled out separation form)