### PR TITLE
Slack Module sendMessageToChannel and clearChannel PR (In Progress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,10 @@ const options = {
   ends_on: '2021-01-10', <-- not required but best practice
 };
 ```
+
+
+## Slack
+- We'll need to add two items to our .env file:
+- `SLACK_TOKEN` can be the bot token from our slack app
+- `SLACK_TOKEN_USER` will be the user token form slack app
+- More clear instructions on setting up a slack app and which scopes are needed will come in the near future. For now we can use the current  Paola-Staging app's bot token for `SLACK_TOKEN` and the current Paola-Staging app's user token for `SLACK_TOKEN_USER`

--- a/slack/index.js
+++ b/slack/index.js
@@ -29,7 +29,7 @@ exports.sendMessageToChannel = async (channel, text) => {
       { method: 'POST', body: JSON.stringify(body), headers },
     );
     const json = await response.json();
-    return json.status;
+    return json;
   } catch (err) {
     return err;
   }
@@ -52,7 +52,7 @@ exports.getChannelHistory = async (channelID) => {
       `https://slack.com/api/conversations.history?token=${process.env.SLACK_TOKEN}&channel=${channelID}&limit=1000`,
       { method: 'GET', headers },
     );
-    return response;
+    return await response.json();
   } catch (err) {
     return err;
   }
@@ -89,6 +89,7 @@ async function deleteMessages(threadTs, messages) {
   const message = messages.shift();
 
   if (message.thread_ts !== threadTs) {
+    // eslint-disable-next-line no-use-before-define
     await fetchAndDeleteMessages(message.thread_ts, ''); // Fetching replies, it will delete main message as well.
   } else {
     const response = await get(apiConfig.deleteApiUrl + message.ts);
@@ -131,5 +132,5 @@ exports.clearChannel = (channelID) => {
   apiConfig.historyApiUrl = `${apiConfig.baseApiUrl}conversations.history?token=${token}&channel=${apiConfig.channel}&count=1000&cursor=`;
   apiConfig.deleteApiUrl = `${apiConfig.baseApiUrl}chat.delete?token=${process.env.SLACK_TOKEN_USER}&channel=${apiConfig.channel}&ts=`;
   apiConfig.repliesApiUrl = `${apiConfig.baseApiUrl}conversations.replies?token=${token}&channel=${apiConfig.channel}&ts=`;
-  fetchAndDeleteMessages(null, '');
+  return fetchAndDeleteMessages(null, '');
 };

--- a/slack/index.js
+++ b/slack/index.js
@@ -1,4 +1,6 @@
+const fetch = require('node-fetch');
 // const { SLACK_API_KEY } = require('./config.js');
+
 // ------------------------------
 // Slack API Integrations (WIP)
 // ------------------------------
@@ -15,3 +17,202 @@ exports.sendMessageToChannel = async () => {
 exports.sendMessageViaDM = async () => {
 
 };
+
+exports.getChannelHistory = async (channelID) => {
+  // console.log(req.body);
+  // const { challenge } = req.body;
+  // POST https://slack.com/api/chat.postMessage
+  // Content-type: application/json
+  // Authorization: Bearer xoxb-your-token
+  // {
+  //   "channel": "YOUR_CHANNEL_ID",
+  //   "text": "Hello world :tada:"
+  // }
+  const headers = {
+    Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+    // 'Content-Type': 'application/x-www-form-urlencoded',
+    channel: 'C01ER2NA0PR'
+  };
+  const body = {
+    channel: 'C01ER2NA0PR',
+  };
+  try {
+    const response = await fetch(
+      `https://slack.com/api/conversations.history?token=${process.env.SLACK_TOKEN}&channel=${channelID}&limit=1000`,
+      { method: 'GET', headers},
+    );
+    const json = await response.json();
+    json.messages.forEach(async message => {
+      console.log(message);
+    });
+    // if (json.error || json.message) throw new Error(json.error || json.message);
+    // return json.status;
+  } catch (err) {
+    // return error.message;
+    console.log(err);
+  }
+};
+
+exports.deleteMessage = async (channelID, ts) => {
+  // console.log(req.body);
+  // const { challenge } = req.body;
+  // POST https://slack.com/api/chat.postMessage
+  // Content-type: application/json
+  // Authorization: Bearer xoxb-your-token
+  // {
+  //   "channel": "YOUR_CHANNEL_ID",
+  //   "text": "Hello world :tada:"
+  // }
+  const headers = {
+    Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+    'Content-Type': 'application/json',
+  };
+  const body = {
+    channel: channelID,
+    ts: ts
+  };
+  try {
+    const response = await fetch(
+      'https://slack.com/api/chat.delete',
+      { method: 'POST', body: JSON.stringify(body), headers },
+    );
+    const json = await response.json();
+    console.log(json);
+    // if (json.error || json.message) throw new Error(json.error || json.message);
+    // return json.status;
+  } catch (err) {
+    // return error.message;
+    console.log(err);
+  }
+};
+
+
+
+
+// CONFIGURATION #######################################################################################################
+
+const token = process.env.SLACK_TOKEN;
+// Legacy tokens are no more supported.
+// Please create an app or use an existing Slack App
+// Add following scopes in your app from "OAuth & Permissions"
+//  - channels:history
+//  - groups:history
+//  - im:history
+//  - mpim:history
+//  - chat:write
+
+// VALIDATION ##########################################################################################################
+
+
+// if (token === 'SLACK TOKEN') {
+//     console.error('Token seems incorrect. Please open the file with an editor and modify the token variable.');
+// }
+
+// let channel = '';
+// if (process.argv[0].indexOf('node') !== -1 && process.argv.length > 2) {
+//     channel = process.argv[2];
+// } else if (process.argv.length > 1) {
+//     channel = process.argv[1];
+// } else {
+//     console.log('Usage: node ./delete-slack-messages.js CHANNEL_ID');
+//     process.exit(1);
+// }
+
+// GLOBALS #############################################################################################################
+
+const https         = require('https');
+const channelConfig = {
+  // baseApiUrl, historyApiUrl, deleteApiUrl, repliesApiUrl, channel
+}
+
+// var baseApiUrl    = 'https://slack.com/api/';
+// var historyApiUrl = `${baseApiUrl}conversations.history?token=${token}&channel=${channel}&count=1000&cursor=`;
+// var deleteApiUrl  = `${baseApiUrl}chat.delete?token=${token}&channel=${channel}&ts=`;
+// var repliesApiUrl = `${baseApiUrl}conversations.replies?token=${token}&channel=${channel}&ts=`
+let   delay         = 300; // Delay between delete operations in milliseconds
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+
+exports.fetchAndDeleteMessages = (channelID) => {
+  //channel = channelID;
+
+  channelConfig.channel = channelID;
+  channelConfig.baseApiUrl    = 'https://slack.com/api/';
+  channelConfig.historyApiUrl = `${channelConfig.baseApiUrl}conversations.history?token=${token}&channel=${channelConfig.channel}&count=1000&cursor=`;
+  channelConfig.deleteApiUrl  = `${channelConfig.baseApiUrl}chat.delete?token=${token}&channel=${channelConfig.channel}&ts=`;
+  channelConfig.repliesApiUrl = `${channelConfig.baseApiUrl}conversations.replies?token=${token}&channel=${channelConfig.channel}&ts=`;
+
+  fetchAndDeleteMessages(null, '');
+}
+
+const sleep = delay => new Promise(r => setTimeout(r, delay));
+const get   = url => new Promise((resolve, reject) =>
+    https
+        .get(url, res => {
+            let body = ''
+
+            res.on('data', chunk => (body += chunk))
+            res.on('end', () => resolve(JSON.parse(body)))
+        })
+        .on('error', reject)
+);
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+async function deleteMessages(threadTs, messages) {
+
+    if (messages.length == 0) {
+        return;
+    }
+
+    const message = messages.shift();
+
+    if (message.thread_ts !== threadTs) {
+        await fetchAndDeleteMessages(message.thread_ts, ''); // Fetching replies, it will delete main message as well.
+    } else {
+        const response = await get(channelConfig.deleteApiUrl + message.ts);
+
+        if (response.ok === true) {
+            console.log(message.ts + (threadTs ? ' reply' : '') + ' deleted!');
+        } else if (response.ok === false) {
+            console.log(message.ts + ' could not be deleted! (' + response.error + ')');
+
+            if (response.error === 'ratelimited') {
+                await sleep(1000);
+                delay += 100; // If rate limited error caught then we need to increase delay.
+                messages.unshift(message);
+            }
+        }
+    }
+
+    await sleep(delay);
+    await deleteMessages(threadTs, messages);
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+async function fetchAndDeleteMessages(threadTs, cursor) {
+
+    const response = await get((threadTs ? channelConfig.repliesApiUrl + threadTs + '&cursor=' : channelConfig.historyApiUrl) + cursor);
+
+    if (!response.ok) {
+        console.error(response.error);
+        return;
+    }
+
+    if (!response.messages || response.messages.length === 0) {
+        return;
+    }
+
+    await deleteMessages(threadTs, response.messages);
+
+    if (response.has_more) {
+        await fetchAndDeleteMessages(threadTs, response.response_metadata.next_cursor);
+    }
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+//fetchAndDeleteMessages(null, '');
+

--- a/slack/index.js
+++ b/slack/index.js
@@ -1,5 +1,10 @@
 const fetch = require('node-fetch');
-// const { SLACK_API_KEY } = require('./config.js');
+const https = require('https');
+
+const apiConfig = {};
+const token = process.env.SLACK_TOKEN;
+let delay = 300;
+
 
 // ------------------------------
 // Slack API Integrations (WIP)
@@ -9,89 +14,52 @@ const fetch = require('node-fetch');
 //       iteration.
 
 // Send a message to a channel
-exports.sendMessageToChannel = async () => {
-
+exports.sendMessageToChannel = async (channel, text) => {
+  const headers = {
+    Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
+    'Content-Type': 'application/json; charset=utf-8',
+  };
+  const body = {
+    channel,
+    text,
+  };
+  try {
+    const response = await fetch(
+      'https://slack.com/api/chat.postMessage',
+      { method: 'POST', body: JSON.stringify(body), headers },
+    );
+    const json = await response.json();
+    return json.status;
+  } catch (err) {
+    return err;
+  }
 };
 
-// Send a message via DM
+// TODO Send a message via DM
 exports.sendMessageViaDM = async () => {
 
 };
 
+// get history of messages from a channel.
 exports.getChannelHistory = async (channelID) => {
-  // console.log(req.body);
-  // const { challenge } = req.body;
-  // POST https://slack.com/api/chat.postMessage
-  // Content-type: application/json
-  // Authorization: Bearer xoxb-your-token
-  // {
-  //   "channel": "YOUR_CHANNEL_ID",
-  //   "text": "Hello world :tada:"
-  // }
   const headers = {
     Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
     // 'Content-Type': 'application/x-www-form-urlencoded',
-    channel: 'C01ER2NA0PR'
-  };
-  const body = {
     channel: 'C01ER2NA0PR',
   };
   try {
     const response = await fetch(
       `https://slack.com/api/conversations.history?token=${process.env.SLACK_TOKEN}&channel=${channelID}&limit=1000`,
-      { method: 'GET', headers},
+      { method: 'GET', headers },
     );
-    const json = await response.json();
-    json.messages.forEach(async message => {
-      console.log(message);
-    });
-    // if (json.error || json.message) throw new Error(json.error || json.message);
-    // return json.status;
+    return response;
   } catch (err) {
-    // return error.message;
-    console.log(err);
+    return err;
   }
 };
 
-exports.deleteMessage = async (channelID, ts) => {
-  // console.log(req.body);
-  // const { challenge } = req.body;
-  // POST https://slack.com/api/chat.postMessage
-  // Content-type: application/json
-  // Authorization: Bearer xoxb-your-token
-  // {
-  //   "channel": "YOUR_CHANNEL_ID",
-  //   "text": "Hello world :tada:"
-  // }
-  const headers = {
-    Authorization: `Bearer ${process.env.SLACK_TOKEN}`,
-    'Content-Type': 'application/json',
-  };
-  const body = {
-    channel: channelID,
-    ts: ts
-  };
-  try {
-    const response = await fetch(
-      'https://slack.com/api/chat.delete',
-      { method: 'POST', body: JSON.stringify(body), headers },
-    );
-    const json = await response.json();
-    console.log(json);
-    // if (json.error || json.message) throw new Error(json.error || json.message);
-    // return json.status;
-  } catch (err) {
-    // return error.message;
-    console.log(err);
-  }
-};
+// CONFIGURATION
 
-
-
-
-// CONFIGURATION #######################################################################################################
-
-const token = process.env.SLACK_TOKEN;
 // Legacy tokens are no more supported.
 // Please create an app or use an existing Slack App
 // Add following scopes in your app from "OAuth & Permissions"
@@ -101,118 +69,67 @@ const token = process.env.SLACK_TOKEN;
 //  - mpim:history
 //  - chat:write
 
-// VALIDATION ##########################################################################################################
+// VALIDATION
 
-
-// if (token === 'SLACK TOKEN') {
-//     console.error('Token seems incorrect. Please open the file with an editor and modify the token variable.');
-// }
-
-// let channel = '';
-// if (process.argv[0].indexOf('node') !== -1 && process.argv.length > 2) {
-//     channel = process.argv[2];
-// } else if (process.argv.length > 1) {
-//     channel = process.argv[1];
-// } else {
-//     console.log('Usage: node ./delete-slack-messages.js CHANNEL_ID');
-//     process.exit(1);
-// }
-
-// GLOBALS #############################################################################################################
-
-const https         = require('https');
-const channelConfig = {
-  // baseApiUrl, historyApiUrl, deleteApiUrl, repliesApiUrl, channel
-}
-
-// var baseApiUrl    = 'https://slack.com/api/';
-// var historyApiUrl = `${baseApiUrl}conversations.history?token=${token}&channel=${channel}&count=1000&cursor=`;
-// var deleteApiUrl  = `${baseApiUrl}chat.delete?token=${token}&channel=${channel}&ts=`;
-// var repliesApiUrl = `${baseApiUrl}conversations.replies?token=${token}&channel=${channel}&ts=`
-let   delay         = 300; // Delay between delete operations in milliseconds
-
-// ---------------------------------------------------------------------------------------------------------------------
-
-
-exports.fetchAndDeleteMessages = (channelID) => {
-  //channel = channelID;
-
-  channelConfig.channel = channelID;
-  channelConfig.baseApiUrl    = 'https://slack.com/api/';
-  channelConfig.historyApiUrl = `${channelConfig.baseApiUrl}conversations.history?token=${token}&channel=${channelConfig.channel}&count=1000&cursor=`;
-  channelConfig.deleteApiUrl  = `${channelConfig.baseApiUrl}chat.delete?token=${token}&channel=${channelConfig.channel}&ts=`;
-  channelConfig.repliesApiUrl = `${channelConfig.baseApiUrl}conversations.replies?token=${token}&channel=${channelConfig.channel}&ts=`;
-
-  fetchAndDeleteMessages(null, '');
-}
-
-const sleep = delay => new Promise(r => setTimeout(r, delay));
-const get   = url => new Promise((resolve, reject) =>
-    https
-        .get(url, res => {
-            let body = ''
-
-            res.on('data', chunk => (body += chunk))
-            res.on('end', () => resolve(JSON.parse(body)))
-        })
-        .on('error', reject)
-);
-
-// ---------------------------------------------------------------------------------------------------------------------
+const sleep = (delayTime) => new Promise((r) => setTimeout(r, delayTime));
+const get = (url) => new Promise((resolve, reject) => https.get(url, (res) => {
+  let body = '';
+  res.on('data', (chunk) => {
+    (body += chunk);
+  });
+  res.on('end', () => resolve(JSON.parse(body)));
+})
+  .on('error', reject));
 
 async function deleteMessages(threadTs, messages) {
+  if (messages.length === 0) {
+    return;
+  }
 
-    if (messages.length == 0) {
-        return;
+  const message = messages.shift();
+
+  if (message.thread_ts !== threadTs) {
+    await fetchAndDeleteMessages(message.thread_ts, ''); // Fetching replies, it will delete main message as well.
+  } else {
+    const response = await get(apiConfig.deleteApiUrl + message.ts);
+
+    if (response.ok === false) {
+      if (response.error === 'ratelimited') {
+        await sleep(1000);
+        delay += 100; // If rate limited error caught then we need to increase delay.
+        messages.unshift(message);
+      }
     }
+  }
 
-    const message = messages.shift();
-
-    if (message.thread_ts !== threadTs) {
-        await fetchAndDeleteMessages(message.thread_ts, ''); // Fetching replies, it will delete main message as well.
-    } else {
-        const response = await get(channelConfig.deleteApiUrl + message.ts);
-
-        if (response.ok === true) {
-            console.log(message.ts + (threadTs ? ' reply' : '') + ' deleted!');
-        } else if (response.ok === false) {
-            console.log(message.ts + ' could not be deleted! (' + response.error + ')');
-
-            if (response.error === 'ratelimited') {
-                await sleep(1000);
-                delay += 100; // If rate limited error caught then we need to increase delay.
-                messages.unshift(message);
-            }
-        }
-    }
-
-    await sleep(delay);
-    await deleteMessages(threadTs, messages);
+  await sleep(delay);
+  await deleteMessages(threadTs, messages);
 }
 
-// ---------------------------------------------------------------------------------------------------------------------
 
 async function fetchAndDeleteMessages(threadTs, cursor) {
+  const response = await get((threadTs ? `${apiConfig.repliesApiUrl + threadTs}&cursor=` : apiConfig.historyApiUrl) + cursor);
 
-    const response = await get((threadTs ? channelConfig.repliesApiUrl + threadTs + '&cursor=' : channelConfig.historyApiUrl) + cursor);
+  if (!response.ok) {
+    return response;
+  }
 
-    if (!response.ok) {
-        console.error(response.error);
-        return;
-    }
+  if (!response.messages || response.messages.length === 0) {
+    return response;
+  }
 
-    if (!response.messages || response.messages.length === 0) {
-        return;
-    }
+  await deleteMessages(threadTs, response.messages);
 
-    await deleteMessages(threadTs, response.messages);
-
-    if (response.has_more) {
-        await fetchAndDeleteMessages(threadTs, response.response_metadata.next_cursor);
-    }
+  if (response.has_more) {
+    await fetchAndDeleteMessages(threadTs, response.response_metadata.next_cursor);
+  }
 }
 
-// ---------------------------------------------------------------------------------------------------------------------
-
-//fetchAndDeleteMessages(null, '');
-
+exports.clearChannel = (channelID) => {
+  apiConfig.channel = channelID;
+  apiConfig.baseApiUrl = 'https://slack.com/api/';
+  apiConfig.historyApiUrl = `${apiConfig.baseApiUrl}conversations.history?token=${token}&channel=${apiConfig.channel}&count=1000&cursor=`;
+  apiConfig.deleteApiUrl = `${apiConfig.baseApiUrl}chat.delete?token=${process.env.SLACK_TOKEN_USER}&channel=${apiConfig.channel}&ts=`;
+  apiConfig.repliesApiUrl = `${apiConfig.baseApiUrl}conversations.replies?token=${token}&channel=${apiConfig.channel}&ts=`;
+  fetchAndDeleteMessages(null, '');
+};

--- a/slack/slack.test.js
+++ b/slack/slack.test.js
@@ -1,0 +1,19 @@
+require('dotenv').config();
+
+const {
+  sendMessageToChannel, clearChannel,
+} = require('.');
+
+
+// Clear out all messages from #delete-messages-test-channel channel in the paola-sandbox workspace
+beforeAll(async () => {
+  await clearChannel('C01ER2NA0PR');
+});
+
+
+describe('sendMessageToChannel', () => {
+  test('Should send a new message to the #delete-messages-test-channel as Paola', async () => {
+    const messageSent = await sendMessageToChannel('C01ER2NA0PR', 'hello');
+    expect(messageSent.ok).toEqual(true);
+  });
+});


### PR DESCRIPTION
Added two main methods to `/slack/index.js`

- `sendMessageToChannel` that sends a message with specified text to a specified channel
- `clearChannel` that accepts a channel parameter and clears all messages and replies within that channel

Created `/slack/slack.test.js`. Basic tests are written for `sendMessageToChannel` with further tests to come. 

- Also updated `README.md` to describe what is needed for authorization. We'll be using the tokens provided by the `Paola-Staging` app in the `paola-sandbox` workspace.


